### PR TITLE
Change t2 instance types to t3, spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 
 # getting-started-cross-account-roles
 
-These example CloudFormation templates are to help you get started with secure cross-account roles. The job-functions/groups below are not exhaustive and this template can be updated to include as many additional groups and roles as is appropriate for your use case (i.e. data scientists, databasea admins, cd/ci systems).
+These example CloudFormation templates are to help you get started with secure cross-account roles. The job-functions/groups below are not exhaustive and this template can be updated to include as many additional groups and roles as is appropriate for your use case (i.e. data scientists, database admins, CI/CD systems).
 
 ![Diagram](example-diagram.png)
- 
+
 ## ***example-aws-federation-account-iam-groups.yaml***
-  
+
 This template creates 3 IAM User Groups: ***DeveloperGroup***, ***NetworkAdminGroup***, and ***AWSAdminGroup***. Each group has policies that only allow for IAM self management (change password, enable MFA token, etc.) and role assumption into the corresponding IAM Roles in the second CloudFormation Template. No other IAM Permissions are granted at this level and any privilege escalation will be done via role-assumption. Users can escalate their privilege by using the following link: https://signin.aws.amazon.com/switchrole?roleName=<IAM ROLE NAME TO BE ASSUMED>&account=<AWS ACCOUNT # or ALIAS>
 
-  
 
 This template should be deployed into your identity or federation account (i.e. wherein your IAM Users are created).  
 
@@ -26,9 +25,6 @@ This template creates 4 cross-account IAM Roles: ***ReadOnlyRole***, ***Develope
 * ***DeveloperRole***: Users assigned to the DeveloperGroup from above will have the ability to assume this IAM Role. This IAM Role has two-tiers of access as determined by the *Environment* flag (condition) in the CloudFormation Parameters. In *Production* environments, the DeveloperRole will only have Read Only access. In **Development** or **Test** (sandbox) environments, the DeveloperRole has significantly more access. For example, RDS:\*, Lambda:\*, ELB:\*, etc etc. Please see the template for more details.
 
 	Additionally, while the DeveloperRole will have access to deploy EC2 instances, they are limited to creating only smaller ec2 instances in a single given region (from a CloudFormation Parameter). This is to help limit costs and improve visibility.
-
-  
-  
 
 This template must be deploy into EACH account that needs to be accessed via these cross-account roles, including the Identity Account (Roles can also be used within an account, not just cross-account. Yes I know it's confusing). Furthermore, any of the IAM Users in the above groups MUST have MFA enabled in order to assume any roles.
 

--- a/example-aws-federated-account-iam-roles.yaml
+++ b/example-aws-federated-account-iam-roles.yaml
@@ -124,11 +124,11 @@ Resources:
           Condition:
             StringEqualsIfExists:
               ec2:InstanceType:
-              - t2.nano
-              - t2.micro
-              - t2.small
-              - t2.medium
-              - t2.large
+              - t3.nano
+              - t3.micro
+              - t3.small
+              - t3.medium
+              - t3.large
               # If restricting developers to a certain region isn't inline with what you're trying to accomplish,
               # you can remove the ec2:Region constraint below
               ec2:Region: !Ref OperatingRegion


### PR DESCRIPTION
t2 instance types changed to t3. Minor spelling and formatting fixes
in README